### PR TITLE
Alterando instruções para o envio de contribuições

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Trabalhe normalmente no branch. Quando desejar enviar seu resultado para o seu r
 git push origin seu_usuario --force
 ```
 
-Assim seu repositório que foi feito fork será atualizado.
+Assim seu repositório que foi feito o fork será atualizado.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ Antes de começar a contruibuir, é necessário reiniciar o número de commits n
 ```
 git remote update
 git reset upstream/master --hard
+```
+Trabalhe normalmente no branch. Quando desejar enviar seu resultado para o seu repositório, faça o push com:
+```
 git push origin seu_usuario --force
 ```
 
-Assim seu repositório que foi feito o fork será atualizado.
+Assim seu repositório que foi feito fork será atualizado.
 
 </details>
 


### PR DESCRIPTION
No README, as instruções para reiniciar o números de commits e o comando "git push origin seu_usuario --force" estão juntas, estou abrindo esta PR com a sugestão de separa-lo em um próximo passo. Para melhorar a compreensão.